### PR TITLE
Add NVIDIA/CUDA support for Windows

### DIFF
--- a/Code/monet_cyclegan/README.md
+++ b/Code/monet_cyclegan/README.md
@@ -98,8 +98,8 @@
 - Open WSL in this folder and create and activate the Conda environment:
 
   ```sh
-  conda env create -f environment-windows-nvidia.yaml
-  conda activate monet-cyclegan-windows-nvidia
+  conda env create -f environment-cuda.yaml
+  conda activate monet-cyclegan-cuda
   ```
   
 For additional information on setting up CUDA on WSL, see the [CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html).

--- a/Code/monet_cyclegan/README.md
+++ b/Code/monet_cyclegan/README.md
@@ -1,4 +1,5 @@
 # Monet CycleGAN
+
 ### Setup (macOS)
 
 - Install [Anaconda](https://www.anaconda.com/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html)

--- a/Code/monet_cyclegan/README.md
+++ b/Code/monet_cyclegan/README.md
@@ -1,31 +1,116 @@
 # Monet CycleGAN
+### Setup (macOS)
 
-### Conda Environment Setup (Windows)
+- Install [Anaconda](https://www.anaconda.com/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
 
-- [Install Anaconda](https://www.anaconda.com/)
-- [Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (WSL is required for GPU support on Windows)
+- Create and activate the Conda environment:
 
-```
-conda env create -f environment-windows.yaml
-conda activate monet-cyclegan-windows
-```
+  ```sh
+  conda env create -f environment-macos.yaml
+  conda activate monet-cyclegan-macos
+  ```
 
-### Conda Environment Setup (macOS)
+### Setup (Windows, CPU only)
 
-- [Install Anaconda](https://www.anaconda.com/)
+- Install [Anaconda](https://www.anaconda.com/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
 
-```
-conda env create -f environment-macos.yaml
-conda activate monet-cyclegan-macos
-```
+- Search for "Environment Variables" on your desktop.
+
+- In the User Variables, edit the "Path" variable.
+
+- Add the following folders to the top of the list:
+
+  - `%USERPROFILE%\anaconda3`
+
+  - `%USERPROFILE%\anaconda3\Scripts`
+
+- Click each OK to exit the window. 
+
+- Open your terminal in this folder and create and activate the Conda environment:
+
+  ```sh
+  conda env create -f environment-windows.yaml
+  conda activate monet-cyclegan-windows
+  ```
+
+### Setup (Windows, NVIDIA/CUDA)
+
+- [Download NVIDIA Drivers](https://www.nvidia.com/Download/index.aspx)
+
+- Search for "Windows Features" on your desktop and enable "Windows Subsystem for Linux" (requires restart)
+
+- Install WSL in Windows Terminal/Command Prompt:
+
+  ```sh
+  wsl --install Ubuntu
+  ```
+
+- Open WSL and remove old GPG key:
+
+  ```sh
+  sudo apt-key del 7fa2af80
+  ```
+
+- Install [Linux x86 CUDA Toolkit](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_local):
+
+  ```sh
+  wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+  sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+  wget https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda-repo-ubuntu2204-12-0-local_12.0.1-525.85.12-1_amd64.deb
+  sudo dpkg -i cuda-repo-ubuntu2204-12-0-local_12.0.1-525.85.12-1_amd64.deb
+  sudo cp /var/cuda-repo-ubuntu2204-12-0-local/cuda-*-keyring.gpg /usr/share/keyrings/
+  sudo apt-get update
+  sudo apt-get -y install cuda
+  ```
+
+- After CUDA installation completes in WSL, **restart your computer**
+
+- In WSL, check to see if you have NVIDIA drivers installed properly:
+
+  ```sh
+  nvidia-smi
+  ```
+  
+- Install [NVIDIA cuDNN](https://developer.nvidia.com/cudnn):
+
+  ```sh
+  sudo apt install nvidia-cudnn
+  ```
+
+- Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html):
+
+  ```sh
+  mkdir -p ~/miniconda3
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
+  bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+  rm -rf ~/miniconda3/miniconda.sh
+  ~/miniconda3/bin/conda init bash
+  ```
+
+- Setup system path configuration:
+
+  ```sh
+  mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+  echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CONDA_PREFIX/lib/' > $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+  ```
+
+- Open WSL in this folder and create and activate the Conda environment:
+
+  ```sh
+  conda env create -f environment-windows-nvidia.yaml
+  conda activate monet-cyclegan-windows-nvidia
+  ```
+  
+For additional information on setting up CUDA on WSL, see the [CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html).
 
 ### Run modules
 
-Run modules from the parent directory of the package.
-Example:
+Run modules from the parent directory of the package (in this case, from the `/Code` folder).
+Here's an example on running the `monet_cyclegan.train` and `monet_cyclegan.generate_images` modules:
 
-```
+```sh
 python -m monet_cyclegan.train
+python -m monet_cyclegan.generate_images
 ```
 
 ### Files/Folders
@@ -53,3 +138,9 @@ Each file in this folder represents a [Python module](https://docs.python.org/3/
 - `train.py`: Train the configured model.
 
 - `utils.py`: Common utilities used throughout the project.
+
+- `environment-macos.yaml`: Conda environment configuration for macOS users.
+
+- `environment-windows.yaml`: Conda environment configuration for Windows users only using CPU.
+
+- `environment-windows-nvidia.yaml`: Conda environment configuration for Windows users with NVIDIA GPUs.

--- a/Code/monet_cyclegan/environment-cuda.yaml
+++ b/Code/monet_cyclegan/environment-cuda.yaml
@@ -1,4 +1,4 @@
-name: monet-cyclegan-windows-nvidia
+name: monet-cyclegan-cuda
 
 channels:
   - conda-forge

--- a/Code/monet_cyclegan/environment-windows-nvidia.yaml
+++ b/Code/monet_cyclegan/environment-windows-nvidia.yaml
@@ -1,0 +1,17 @@
+name: monet-cyclegan-windows-nvidia
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.9
+  - pip
+  - ipykernel
+  - cudatoolkit
+  - cudnn
+
+  - pip:
+      - tensorflow
+      - tensorflow-addons
+      - matplotlib
+      - pillow


### PR DESCRIPTION
We can now train and generate images using NVIDIA GPU on Windows! The only dependencies I had to include in the Conda environment were:

- `cudatoolkit`
- `cudnn`

which I included in a separate `environment-cuda.yaml` file.

There is a lot of additional work required to completely setup CUDA support, including installing WSL. These details are mentioned in the README changes.

I trained the model on the sample data using five epochs successfully (took less than three minutes):

```
(monet-cyclegan-windows) nguyene@MSI:/mnt/c/Users/19ngu/Workspace/cis-4496-project/Code$ python -m monet_cyclegan.train
2023-02-16 04:24:48.990399: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-02-16 04:24:49.340057: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2023-02-16 04:24:50.683976: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/python3.9/site-packages/tensorrt/:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib/python3.9/site-packages/tensorrt/
2023-02-16 04:24:50.687468: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/python3.9/site-packages/tensorrt/:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib/python3.9/site-packages/tensorrt/
2023-02-16 04:24:50.687492: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
2023-02-16 04:24:52.241891: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:52.459783: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:52.459859: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:52.463179: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-02-16 04:24:52.465759: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:52.465813: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:52.465848: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:53.612126: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:53.612774: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:53.612824: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1700] Could not identify NUMA node of platform GPU id 0, defaulting to 0.  Your kernel may not have been built with NUMA support.
2023-02-16 04:24:53.612870: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:24:53.612908: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1613] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 3417 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 3060 Laptop GPU, pci bus id: 0000:01:00.0, compute capability: 8.6
Epoch 1/5
2023-02-16 04:25:15.918339: E tensorflow/core/grappler/optimizers/meta_optimizer.cc:954] layout failed: INVALID_ARGUMENT: Size of values 0 does not match size of permutation 4 @ fanin shape inStatefulPartitionedCall/model_1/sequential_23/dropout_3/dropout_2/SelectV2-2-TransposeNHWCToNCHW-LayoutOptimizer
2023-02-16 04:25:22.385834: I tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:428] Loaded cuDNN version 8401
2023-02-16 04:25:24.604006: I tensorflow/tsl/platform/default/subprocess.cc:304] Start cannot spawn child process: No such file or directory
2023-02-16 04:25:25.066429: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 4.16GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.066482: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 4.16GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.658510: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 2.15GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.658556: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 2.15GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.667906: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 2.15GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.667959: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 2.15GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.678425: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 2.15GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.678478: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 2.15GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:25.868001: I tensorflow/compiler/xla/service/service.cc:173] XLA service 0x7f727001c8d0 initialized for platform CUDA (this does not guarantee that XLA will be used). Devices:
2023-02-16 04:25:25.868044: I tensorflow/compiler/xla/service/service.cc:181]   StreamExecutor device (0): NVIDIA GeForce RTX 3060 Laptop GPU, Compute Capability 8.6
2023-02-16 04:25:25.896172: I tensorflow/compiler/mlir/tensorflow/utils/dump_mlir_util.cc:268] disabling MLIR crash reproducer, set env var `MLIR_CRASH_REPRODUCER_DIRECTORY` to enable.
2023-02-16 04:25:26.140196: I tensorflow/tsl/platform/default/subprocess.cc:304] Start cannot spawn child process: No such file or directory
2023-02-16 04:25:26.186105: I tensorflow/compiler/jit/xla_compilation_cache.cc:477] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.
2023-02-16 04:25:26.623248: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 4.16GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
2023-02-16 04:25:26.623295: W tensorflow/tsl/framework/bfc_allocator.cc:290] Allocator (GPU_0_bfc) ran out of memory trying to allocate 4.16GiB with freed_by_count=0. The caller indicates that this is not a failure, but this may mean that there could be performance gains if more memory were available.
60/60 [==============================] - 55s 321ms/step - monet_generator_loss: 8.6383 - photo_generator_loss: 9.0670 - monet_discriminator_loss: 0.6486 - photo_discriminator_loss: 0.6174
Epoch 2/5
60/60 [==============================] - 19s 316ms/step - monet_generator_loss: 5.4410 - photo_generator_loss: 5.6172 - monet_discriminator_loss: 0.4650 - photo_discriminator_loss: 0.4239
Epoch 3/5
60/60 [==============================] - 19s 314ms/step - monet_generator_loss: 5.6580 - photo_generator_loss: 5.9372 - monet_discriminator_loss: 0.4307 - photo_discriminator_loss: 0.3384
Epoch 4/5
60/60 [==============================] - 19s 315ms/step - monet_generator_loss: 5.2863 - photo_generator_loss: 5.8369 - monet_discriminator_loss: 0.6715 - photo_discriminator_loss: 0.4301
Epoch 5/5
60/60 [==============================] - 19s 315ms/step - monet_generator_loss: 4.6289 - photo_generator_loss: 5.1988 - monet_discriminator_loss: 0.6617 - photo_discriminator_loss: 0.4337
```

I was also able to generate the images successfully and fairly quickly:

```
(monet-cyclegan-windows) nguyene@MSI:/mnt/c/Users/19ngu/Workspace/cis-4496-project/Code$ python -m monet_cyclegan.generate_images
2023-02-16 04:28:44.378513: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-02-16 04:28:44.469850: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2023-02-16 04:28:44.924082: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/python3.9/site-packages/tensorrt/:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib/python3.9/site-packages/tensorrt/
2023-02-16 04:28:44.933336: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: :/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/:/home/nguyene/miniconda3/lib/python3.9/site-packages/tensorrt/:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib:/home/nguyene/miniconda3/envs/monet-cyclegan-windows/lib/python3.9/site-packages/tensorrt/
2023-02-16 04:28:44.933417: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.
2023-02-16 04:28:45.538050: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:28:45.586747: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:28:45.586844: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:28:45.587449: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F AVX512_VNNI FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-02-16 04:28:45.588891: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:28:45.588937: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:28:45.588967: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
Your kernel may have been built without NUMA support.
2023-02-16 04:28:46.118861: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:967] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
```