### PR TITLE
Downgrade to Python 3.8

### DIFF
--- a/Code/monet_cyclegan/create_model.py
+++ b/Code/monet_cyclegan/create_model.py
@@ -23,11 +23,11 @@ def create_model() -> CycleGan:
         def generator_loss(generated: tf.keras.Model) -> tf.Tensor:
             return tf.keras.losses.BinaryCrossentropy(from_logits=True, reduction=tf.keras.losses.Reduction.NONE)(tf.ones_like(generated), generated)
 
-        def calc_cycle_loss(real_image: tf.Tensor, cycled_image: tf.Tensor, LAMBDA: float) -> float:
+        def calc_cycle_loss(real_image: tf.Tensor, cycled_image: tf.Tensor, LAMBDA: float) -> tf.Tensor:
             loss1 = tf.reduce_mean(tf.abs(real_image - cycled_image))
             return LAMBDA * loss1
 
-        def identity_loss(real_image: tf.Tensor, same_image: tf.Tensor, LAMBDA: float) -> float:
+        def identity_loss(real_image: tf.Tensor, same_image: tf.Tensor, LAMBDA: float) -> tf.Tensor:
             loss = tf.reduce_mean(tf.abs(real_image - same_image))
             return LAMBDA * 0.5 * loss
 

--- a/Code/monet_cyclegan/environment-cuda.yaml
+++ b/Code/monet_cyclegan/environment-cuda.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.8
   - pip
   - ipykernel
   - cudatoolkit

--- a/Code/monet_cyclegan/environment-macos.yaml
+++ b/Code/monet_cyclegan/environment-macos.yaml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.8
   - pip
   - tensorflow-deps
   - ipykernel

--- a/Code/monet_cyclegan/environment-windows.yaml
+++ b/Code/monet_cyclegan/environment-windows.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.8
   - pip
   - ipykernel
 

--- a/Code/monet_cyclegan/model.py
+++ b/Code/monet_cyclegan/model.py
@@ -22,7 +22,7 @@ class CycleGan(tf.keras.Model):
         self.identity_loss_fn = identity_loss_fn
     
     @tf.function
-    def train_step(self, batch_data: tuple[tf.Tensor, tf.Tensor]):
+    def train_step(self, batch_data: 'tuple[tf.Tensor, tf.Tensor]'):
         real_monet, real_photo = batch_data
 
         with tf.GradientTape(persistent=True) as tape:

--- a/Code/monet_cyclegan/utils.py
+++ b/Code/monet_cyclegan/utils.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-def decode_image(image: tf.io.FixedLenFeature, image_size: list[int] = [256, 256]) -> tf.Tensor:
+def decode_image(image: tf.io.FixedLenFeature, image_size: 'list[int]' = [256, 256]) -> tf.Tensor:
     image = tf.image.decode_jpeg(image, channels=3)
     image = (tf.cast(image, tf.float32) / 127.5) - 1
     image = tf.reshape(image, [*image_size, 3])
@@ -16,7 +16,7 @@ def read_tfrecord(example: tf.Tensor) -> tf.Tensor:
     image = decode_image(example['image'])
     return image
 
-def read_tfrecords(filenames: list[str]) -> tf.data.TFRecordDataset:
+def read_tfrecords(filenames: 'list[str]') -> tf.data.TFRecordDataset:
     dataset = tf.data.TFRecordDataset(filenames)
     dataset = dataset.map(read_tfrecord, num_parallel_calls=tf.data.experimental.AUTOTUNE)
     return dataset


### PR DESCRIPTION
Downgraded to Python 3.8 in all Conda environments.

Tested on macOS:

```
python -m monet_cyclegan.train
Metal device set to: Apple M1

systemMemory: 8.00 GB
maxCacheSize: 2.67 GB

2023-02-16 15:54:19.082217: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:306] Could not identify NUMA node of platform GPU ID 0, defaulting to 0. Your kernel may not have been built with NUMA support.
2023-02-16 15:54:19.082481: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:272] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 0 MB memory) -> physical PluggableDevice (device: 0, name: METAL, pci bus id: <undefined>)
2023-02-16 15:54:20.547392: W tensorflow/core/platform/profile_utils/cpu_utils.cc:128] Failed to get CPU frequency: 0 Hz
2023-02-16 15:54:31.542170: I tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.cc:114] Plugin optimizer for device_type GPU is enabled.
60/60 [==============================] - 147s 2s/step - monet_generator_loss: 8.5496 - photo_generator_loss: 8.9232 - monet_discriminator_loss: 0.6534 - photo_discriminator_loss: 0.6214
```

```
❯ python -m monet_cyclegan.generate_images
Metal device set to: Apple M1

systemMemory: 8.00 GB
maxCacheSize: 2.67 GB

2023-02-16 15:57:31.720232: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:306] Could not identify NUMA node of platform GPU ID 0, defaulting to 0. Your kernel may not have been built with NUMA support.
2023-02-16 15:57:31.720478: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:272] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 0 MB memory) -> physical PluggableDevice (device: 0, name: METAL, pci bus id: <undefined>)
2023-02-16 15:57:33.297471: W tensorflow/core/platform/profile_utils/cpu_utils.cc:128] Failed to get CPU frequency: 0 Hz
```