### PR TITLE
Refactor code and add ability to generate images from different folders

### DIFF
--- a/Code/monet_cyclegan/data_acquisition/datasets.py
+++ b/Code/monet_cyclegan/data_acquisition/datasets.py
@@ -1,4 +1,4 @@
-from typing import List
+import os
 
 import tensorflow as tf
 
@@ -6,58 +6,35 @@ from .utils import read_tfrecorddataset, get_filenames
 from ..consts import MONET_TFREC_DIR, PHOTO_TFREC_DIR
 
 
-def monet_tfrec_filenames(image_dir: str = MONET_TFREC_DIR) -> List[str]:
-    """Get the list of filenames for each Monet painting.
-
-    Returns:
-        List of filenames for each Monet painting.
-    """
-
-    return get_filenames(image_dir=image_dir, ext='tfrec')
-
-
-def photo_tfrec_filenames(image_dir: str = PHOTO_TFREC_DIR) -> List[str]:
-    """Get the list of filenames for each photo.
-
-    Returns:
-        List of filenames for each photo.
-    """
-
-    return get_filenames(image_dir=image_dir, ext='tfrec')
-
-
-def monet_tfrecorddataset(image_dir: str = MONET_TFREC_DIR) -> tf.data.TFRecordDataset:
-    """The set of Monet paintings as a `TFRecordDataset`.
-
-    Returns:
-        The Monet painting dataset in `TFRecordDataset` format.
-    """
-
-    return read_tfrecorddataset(filenames=monet_tfrec_filenames(image_dir=image_dir))
-
-
-def photo_tfrecorddataset(image_dir: str = PHOTO_TFREC_DIR) -> tf.data.TFRecordDataset:
-    """The set of photos as a `TFRecordDataset`.
-
-    Returns:
-        The photo dataset in `TFRecordDataset` format.
-    """
-
-    return read_tfrecorddataset(filenames=photo_tfrec_filenames(image_dir=image_dir))
-
-
-def load_dataset(monet_dir: str, photo_dir: str, batch_size: int = 1) -> tf.data.Dataset:
+def load_dataset(monet_dir: str = MONET_TFREC_DIR,
+                 photo_dir: str = PHOTO_TFREC_DIR,
+                 image_ext: str = 'tfrec',
+                 batch_size: int = 1) -> tf.data.Dataset:
     """Load the dataset to be used for training the CycleGAN.
 
     Args:
-        batch_size: Batch size of the dataset.
         monet_dir: Directory of Monet painting images.
         photo_dir: Directory of photo images.
+        image_ext: File extension of the images.
+        batch_size: Batch size of the dataset.
 
     Returns:
         The Monet paintings and photos zipped into one dataset.
     """
 
-    monets = monet_tfrecorddataset(image_dir=monet_dir).batch(batch_size, drop_remainder=True)
-    photos = photo_tfrecorddataset(image_dir=photo_dir).batch(batch_size, drop_remainder=True)
-    return tf.data.Dataset.zip((monets, photos))
+    if not os.path.isdir(monet_dir):
+        raise OSError(f'Can\'t find directory "{monet_dir}".')
+
+    if not os.path.isdir(photo_dir):
+        raise OSError(f'Can\'t find directory "{photo_dir}".')
+
+    if image_ext == 'tfrec':
+        monet_dataset = read_tfrecorddataset(filenames=get_filenames(image_dir=monet_dir, ext=image_ext))
+        photo_dataset = read_tfrecorddataset(filenames=get_filenames(image_dir=photo_dir, ext=image_ext))
+    else:
+        raise ValueError(f'Invalid file extension {image_ext}.')
+
+    monet_dataset = monet_dataset.batch(batch_size, drop_remainder=True)
+    photo_dataset = photo_dataset.batch(batch_size, drop_remainder=True)
+
+    return tf.data.Dataset.zip((monet_dataset, photo_dataset))

--- a/Code/monet_cyclegan/data_acquisition/download_dataset.py
+++ b/Code/monet_cyclegan/data_acquisition/download_dataset.py
@@ -12,8 +12,7 @@ def download_kaggle_dataset(url: str = KAGGLE_DATASET_URL,
     Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     if len(os.listdir(output_dir)) != 0:
-        print(f'ERROR: Directory "{output_dir}" is not empty.')
-        return
+        raise OSError(f'Directory "{output_dir}" is not empty.')
 
     download_extract_zip(url, output_dir)
 

--- a/Code/monet_cyclegan/data_acquisition/utils.py
+++ b/Code/monet_cyclegan/data_acquisition/utils.py
@@ -34,16 +34,16 @@ def read_image(path: str,
                width: int,
                height: int,
                channels: int) -> tf.Tensor:
-    """Read and decode a JPEG image file to an uint8 `Tensor`
+    """Read and decode an image file to an uint8 `Tensor`
 
     Args:
-        path: Path of the JPEG image.
+        path: Path of the image.
         width: The width of the decoded image.
         height: The height of the decoded image.
         channels: Number of color channels for the decoded image.
 
     Returns:
-        The JPEG image decoded as an uint8 `Tensor`.
+        The image decoded as an uint8 `Tensor`.
     """
 
     image = tf.io.read_file(path)

--- a/Code/monet_cyclegan/deployment/generate_images.py
+++ b/Code/monet_cyclegan/deployment/generate_images.py
@@ -3,14 +3,12 @@ Generates images from the trained model.
 """
 
 import os
-import sys
 from argparse import ArgumentParser
 
 from .load_model import load_cyclegan_model
 from .utils import translate_image, save_image, make_directory
 from ..consts import IMAGE_SIZE, CHANNELS, PHOTO_TFREC_DIR
-from ..data_acquisition.datasets import photo_tfrecorddataset
-from ..data_acquisition.utils import read_image
+from ..data_acquisition.utils import read_image, read_tfrecorddataset, get_filenames
 from ..modeling.model import CycleGan
 
 
@@ -22,6 +20,9 @@ def generate_image(cyclegan_model: CycleGan, input_path: str, output_dir: str) -
         input_path: Path of the image to be translated.
         output_dir: Directory where the generated image will be saved.
     """
+
+    if not os.path.isfile(input_path):
+        raise FileNotFoundError(f'Could not find file "{input_path}".')
 
     image = read_image(path=input_path,
                        width=IMAGE_SIZE[0],
@@ -37,31 +38,47 @@ def generate_image(cyclegan_model: CycleGan, input_path: str, output_dir: str) -
                output_path=f'{output_dir}/monet-{filename}')
 
 
-def generate_images(cyclegan_model: CycleGan, input_dir: str, output_dir: str) -> None:
+def generate_images(cyclegan_model: CycleGan, input_dir: str, input_ext: str, output_dir: str) -> None:
     """Use a CycleGAN model to translate images to Monet paintings and save them.
 
     Args:
         cyclegan_model: The CycleGAN model to be used for image generation.
         input_dir: Directory of images to be translated.
+        input_ext: File extension of the input image format.
         output_dir: Directory where the generated images will be saved.
     """
 
-    photos = photo_tfrecorddataset(image_dir=input_dir).batch(1)
-    make_directory(output_dir)
-    for i, image in enumerate(photos):
-        generated_image = translate_image(cyclegan_model=cyclegan_model, image=image)
-        save_image(image=generated_image, output_path=f'{output_dir}/{i}.jpg')
+    if not os.path.isdir(input_dir):
+        raise FileNotFoundError(f'Could not find directory "{input_dir}".')
+
+    if input_ext == 'tfrec':
+        photos = read_tfrecorddataset(filenames=get_filenames(image_dir=input_dir,
+                                                              ext=input_ext)).batch(1)
+
+        make_directory(output_dir)
+
+        for i, image in enumerate(photos):
+            generated_image = translate_image(cyclegan_model=cyclegan_model,
+                                              image=image)
+
+            save_image(image=generated_image,
+                       output_path=f'{output_dir}/{i}.jpg')
+    else:
+        make_directory(output_dir)
+
+        for i, filename in enumerate(get_filenames(image_dir=input_dir, ext=input_ext)):
+            generate_image(cyclegan_model=cyclegan_model,
+                           input_path=filename,
+                           output_dir=output_dir)
 
 
 def main() -> None:
     parser = ArgumentParser()
     parser.add_argument('--dir', type=str, default=PHOTO_TFREC_DIR)
+    parser.add_argument('--ext', type=str, default='tfrec')
     parser.add_argument('--file', '-f', type=str)
+    parser.add_argument('--output', '-o', type=str, default='../submission_images')
     args = parser.parse_args()
-
-    if not os.path.isdir(args.dir):
-        print(f"ERROR: Can't find {args.dir}")
-        sys.exit(1)
 
     model = load_cyclegan_model()
 
@@ -72,7 +89,8 @@ def main() -> None:
     else:
         generate_images(cyclegan_model=model,
                         input_dir=args.dir,
-                        output_dir='../submission_images')
+                        input_ext=args.ext,
+                        output_dir=args.output)
 
 
 if __name__ == '__main__':

--- a/Code/monet_cyclegan/deployment/load_model.py
+++ b/Code/monet_cyclegan/deployment/load_model.py
@@ -1,4 +1,4 @@
-import sys
+import os
 
 from ..modeling.create_model import create_cyclegan_model
 from ..modeling.model import CycleGan
@@ -16,12 +16,15 @@ def load_cyclegan_model(monet_generator_weights_path: str = 'photo2monet.h5',
         The reconstructed CycleGAN model.
     """
 
+    if not os.path.isfile(monet_generator_weights_path):
+        raise FileNotFoundError(f'Could not find {monet_generator_weights_path}.')
+
+    if not os.path.isfile(photo_generator_weights_path):
+        raise FileNotFoundError(f'Could not find {photo_generator_weights_path}.')
+
     cyclegan_model = create_cyclegan_model()
 
-    try:
-        cyclegan_model.monet_generator.load_weights(monet_generator_weights_path)
-        cyclegan_model.photo_generator.load_weights(photo_generator_weights_path)
-    except ImportError:
-        sys.exit('ERROR: CycleGAN model not trained yet.')
+    cyclegan_model.monet_generator.load_weights(monet_generator_weights_path)
+    cyclegan_model.photo_generator.load_weights(photo_generator_weights_path)
 
     return cyclegan_model

--- a/Code/monet_cyclegan/modeling/train.py
+++ b/Code/monet_cyclegan/modeling/train.py
@@ -2,8 +2,6 @@
 Compile and train the CycleGAN model.
 """
 
-import os
-import sys
 from argparse import ArgumentParser
 
 import tensorflow as tf
@@ -53,14 +51,6 @@ def main() -> None:
 
     dataset = load_dataset(monet_dir=args.monet_dir, photo_dir=args.photo_dir, batch_size=BATCH_SIZE)
 
-    if not os.path.isdir(args.monet_dir):
-        print(f"ERROR: Can't find {args.monet_dir}")
-        sys.exit(1)
-
-    if not os.path.isdir(args.photo_dir):
-        print(f"ERROR: Can't find {args.photo_dir}")
-        sys.exit(1)
-
     model = create_cyclegan_model()
 
     train_model(cyclegan_model=model,
@@ -68,6 +58,7 @@ def main() -> None:
                 train_dataset=dataset)
 
     save_weights(cyclegan_model=model)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Refactored some code and error handling stuff. Also added the ability to generate images from different folders.

Functions deleted:

- `data_acquisition/datasets/monet_tfrec_filenames`
- `data_acquisition/datasets/photo_tfrec_filenames`
- `data_acquisition/datasets/monet_tfrecorddataset`
- `data_acquisition/datasets/photo_tfrecorddataset`

Successfully tests on macOS:

```
python -m monet_cyclegan.modeling.train
python -m monet_cyclegan.deployment.generate_images --dir samples-photos --ext jpg
python -m monet_cyclegan.deployment.generate_images
```