### PR TITLE
Add RGB distribution plot for single image

### DIFF
--- a/Code/monet_cyclegan/data_acquisition/__init__.py
+++ b/Code/monet_cyclegan/data_acquisition/__init__.py
@@ -1,2 +1,3 @@
 from . import datasets
 from . import download_dataset
+from . import rgb_distribution

--- a/Code/monet_cyclegan/data_acquisition/rgb_distribution.py
+++ b/Code/monet_cyclegan/data_acquisition/rgb_distribution.py
@@ -1,0 +1,33 @@
+import os
+
+import matplotlib.pyplot as plt
+import tensorflow as tf
+
+from ..consts import IMAGE_SIZE, CHANNELS
+from ..utils import read_image, tensor_to_image
+
+
+def plot_rgb_distribution(input_path: str) -> None:
+    """Plot the RGB distribution of a given image.
+
+    Args:
+        input_path: The path of the image.
+    """
+
+    if not os.path.isfile(input_path):
+        raise FileNotFoundError(f'Could not find file "{input_path}".')
+
+    image = read_image(path=input_path,
+                       width=IMAGE_SIZE[0],
+                       height=IMAGE_SIZE[1],
+                       channels=CHANNELS)[0]
+    image = tensor_to_image(image)
+
+    red_channel = tf.reshape(image[:, :, 0], [-1]).numpy()
+    green_channel = tf.reshape(image[:, :, 1], [-1]).numpy()
+    blue_channel = tf.reshape(image[:, :, 2], [-1]).numpy()
+
+    colors = ['red', 'green', 'blue']
+    plt.title(f'RGB Distribution of "{input_path}"')
+    plt.hist([red_channel, blue_channel, green_channel], stacked=True, color=colors)
+    plt.show(block=True)

--- a/Code/monet_cyclegan/scripts/__init__.py
+++ b/Code/monet_cyclegan/scripts/__init__.py
@@ -1,4 +1,5 @@
 from . import calculate_fid
+from . import plot_rgb_distribution
 from . import download_dataset
 from . import generate_images
 from . import train

--- a/Code/monet_cyclegan/scripts/plot_rgb_distribution.py
+++ b/Code/monet_cyclegan/scripts/plot_rgb_distribution.py
@@ -1,0 +1,10 @@
+from argparse import ArgumentParser
+
+from ..data_acquisition.rgb_distribution import plot_rgb_distribution
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--file', '-f', type=str, required=True)
+    args = parser.parse_args()
+
+    plot_rgb_distribution(input_path=args.file)


### PR DESCRIPTION
Plot RGB distribution of a single image.

Command:

```commandline
python -m monet_cyclegan.scripts.plot_rgb_distribution -f [image_path]
```