### PR TITLE
Add bins argument to RGB distribution plot

### DIFF
--- a/Code/monet_cyclegan/data_acquisition/rgb_distribution.py
+++ b/Code/monet_cyclegan/data_acquisition/rgb_distribution.py
@@ -7,11 +7,12 @@ from ..consts import IMAGE_SIZE, CHANNELS
 from ..utils import read_image, tensor_to_image
 
 
-def plot_rgb_distribution(input_path: str) -> None:
+def plot_rgb_distribution(input_path: str, bins: int) -> None:
     """Plot the RGB distribution of a given image.
 
     Args:
         input_path: The path of the image.
+        bins: Number of bins.
     """
 
     if not os.path.isfile(input_path):
@@ -29,5 +30,5 @@ def plot_rgb_distribution(input_path: str) -> None:
 
     colors = ['red', 'green', 'blue']
     plt.title(f'RGB Distribution of "{input_path}"')
-    plt.hist(x=[red_channel, blue_channel, green_channel], stacked=True, color=colors)
+    plt.hist(x=[red_channel, blue_channel, green_channel], stacked=True, color=colors, bins=bins)
     plt.show(block=True)

--- a/Code/monet_cyclegan/scripts/plot_rgb_distribution.py
+++ b/Code/monet_cyclegan/scripts/plot_rgb_distribution.py
@@ -6,9 +6,10 @@ from ..data_acquisition.rgb_distribution import plot_rgb_distribution
 def main():
     parser = ArgumentParser()
     parser.add_argument('--file', '-f', type=str, required=True)
+    parser.add_argument('--bins', type=int, default=None)
     args = parser.parse_args()
 
-    plot_rgb_distribution(input_path=args.file)
+    plot_rgb_distribution(input_path=args.file, bins=args.bins)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add bins argument to RGB distribution plot.

Tested succesfully on macOS:

```commandline
python -m monet_cyclegan.scripts.plot_rgb_distribution -f sample-jpg/corgi.jpg --bins 32
```