### PR TITLE
Add pytorch-fid

### DIFF
--- a/Code/monet_cyclegan/environment-cuda.yaml
+++ b/Code/monet_cyclegan/environment-cuda.yaml
@@ -18,3 +18,4 @@ dependencies:
       - pillow
       - scipy
       - seaborn
+      - pytorch-fid

--- a/Code/monet_cyclegan/environment-macos.yaml
+++ b/Code/monet_cyclegan/environment-macos.yaml
@@ -19,3 +19,4 @@ dependencies:
       - pillow
       - scipy
       - seaborn
+      - pytorch-fid

--- a/Code/monet_cyclegan/environment-windows.yaml
+++ b/Code/monet_cyclegan/environment-windows.yaml
@@ -16,3 +16,4 @@ dependencies:
       - pillow
       - scipy
       - seaborn
+      - pytorch-fid


### PR DESCRIPTION
Add pytorch-fid to calculate FID scores for development purposes. We want our FID code to provide similar results, which it does not yet do (if this is too difficult then we can just use pytorch-fid instead of implementing FID ourselves).

To use pytorch-fid, simply run

```
python -m pytorch_fid path/to/dataset1 path/to/dataset2
```

where `dataset1` and `dataset2` are folders of JPG/PNG images.