### PR TITLE
Fix imports and add logging

### DIFF
--- a/Code/monet_cyclegan/deployment/__init__.py
+++ b/Code/monet_cyclegan/deployment/__init__.py
@@ -1,3 +1,2 @@
-from . import fid
 from . import generate_images
 from . import load_model

--- a/Code/monet_cyclegan/scripts/calculate_fid.py
+++ b/Code/monet_cyclegan/scripts/calculate_fid.py
@@ -1,10 +1,9 @@
 import argparse
+import logging
 import os
 
-from ..consts import PHOTO_TFREC_DIR, MONET_TFREC_DIR, BUILD_DIR, MONET_GENERATOR_WEIGHT_FILENAME, \
-    PHOTO_GENERATOR_WEIGHT_FILENAME, EPOCHS
-from ..deployment.load_model import load_cyclegan_model
-from ..utils import configure_logger, log_args, read_tfrecorddataset, get_filenames
+from ..consts import BUILD_DIR, EPOCHS
+from ..utils import configure_logger, log_args
 
 
 def main():
@@ -20,8 +19,12 @@ def main():
     configure_logger(log_dir=log_dir)
     log_args(args=args)
 
-    fid = os.system('python -m pytorch_fid '+args.painting_dir+' '+args.transformed_photos_dir)
-    print(fid)
+    fid_output = os.popen('python -m pytorch_fid ' + args.painting_dir + ' ' + args.transformed_photos_dir).read()
+
+    logger = logging.getLogger()
+    logger.info(fid_output)
+
+    print(fid_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed the imports and added logging for the FID score.

Ran this command:
```
python -m monet_cyclegan.scripts.calculate_fid --painting_dir build/epoch1/images --transformed_photos_dir build/epoch1/images-original
```

The log file `Code/monet_cyclegan/build/epoch1/2023-03-02 05:05:16.834.log`:

```
2023-03-02 00:05:16.834 root.log_args INFO epochs: 1
2023-03-02 00:05:16.835 root.log_args INFO output: ./build
2023-03-02 00:05:16.835 root.log_args INFO painting_dir: build/epoch1/images
2023-03-02 00:05:16.835 root.log_args INFO transformed_photos_dir: build/epoch1/images-original
2023-03-02 00:05:40.018 root.main INFO Warning: batch size is bigger than the data size. Setting batch size to data size
Warning: batch size is bigger than the data size. Setting batch size to data size
FID:  532.2995439334572
```