### PR TITLE
Add script to convert HDF5 to SavedModel format

### DIFF
--- a/Code/monet_cyclegan/deployment/load_model.py
+++ b/Code/monet_cyclegan/deployment/load_model.py
@@ -19,15 +19,39 @@ def load_cyclegan_model(
         The reconstructed CycleGAN model.
     """
 
-    if not os.path.isdir(photo2painting_generator_weights_path):
-        raise FileNotFoundError(f'Could not find {photo2painting_generator_weights_path}.')
-
-    if not os.path.isdir(painting2photo_generator_weights_path):
-        raise FileNotFoundError(f'Could not find {painting2photo_generator_weights_path}.')
-
     cyclegan_model = create_cyclegan_model()
 
-    cyclegan_model.painting_generator = tf.keras.models.load_model(photo2painting_generator_weights_path)
-    cyclegan_model.photo_generator = tf.keras.models.load_model(painting2photo_generator_weights_path)
+    photo_generator_path_tokens = os.path.splitext(painting2photo_generator_weights_path)
+    painting_generator_path_tokens = os.path.splitext(photo2painting_generator_weights_path)
+
+    if len(photo_generator_path_tokens) == 2:
+        if not os.path.isfile(painting2photo_generator_weights_path):
+            raise FileNotFoundError(f'Could not find {painting2photo_generator_weights_path}.')
+
+        cyclegan_model.photo_generator.load_weights(painting2photo_generator_weights_path)
+
+    elif len(photo_generator_path_tokens) == 1:
+        if not os.path.isdir(painting2photo_generator_weights_path):
+            raise FileNotFoundError(f'Could not find {painting2photo_generator_weights_path}.')
+
+        cyclegan_model.photo_generator = tf.keras.models.load_model(painting2photo_generator_weights_path)
+
+    else:
+        raise IOError(f'Invalid photo generator path: "{painting2photo_generator_weights_path}"')
+
+    if len(painting_generator_path_tokens) == 2:
+        if not os.path.isfile(photo2painting_generator_weights_path):
+            raise FileNotFoundError(f'Could not find {photo2painting_generator_weights_path}.')
+
+        cyclegan_model.painting_generator.load_weights(photo2painting_generator_weights_path)
+
+    elif len(painting_generator_path_tokens) == 1:
+        if not os.path.isdir(photo2painting_generator_weights_path):
+            raise FileNotFoundError(f'Could not find {photo2painting_generator_weights_path}.')
+
+        cyclegan_model.painting_generator = tf.keras.models.load_model(photo2painting_generator_weights_path)
+
+    else:
+        raise IOError(f'Invalid painting generator path: "{photo2painting_generator_weights_path}"')
 
     return cyclegan_model

--- a/Code/monet_cyclegan/scripts/__init__.py
+++ b/Code/monet_cyclegan/scripts/__init__.py
@@ -2,6 +2,7 @@ from . import augment_images
 from . import calculate_fid
 from . import download_dataset
 from . import generate_images
+from . import h5_to_saved_model
 from . import plot_rgb_distribution
 from . import save_tfjs_weights
 from . import train

--- a/Code/monet_cyclegan/scripts/h5_to_saved_model.py
+++ b/Code/monet_cyclegan/scripts/h5_to_saved_model.py
@@ -1,0 +1,26 @@
+from argparse import ArgumentParser
+
+import tensorflow as tf
+
+from ..deployment.load_model import load_cyclegan_model
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('--photo2painting', type=str, required=True, help='Path of photo2painting.h5 file.')
+    parser.add_argument('--painting2photo', type=str, required=True, help='Path of painting2photo.h5 file.')
+    parser.add_argument('--output', '-o', type=str, required=True, help='Path of output directory.')
+    args = parser.parse_args()
+
+    model = load_cyclegan_model(photo2painting_generator_weights_path=args.photo2painting,
+                                painting2photo_generator_weights_path=args.painting2photo)
+
+    painting_generator_path = f'{args.output}/photo2painting'
+    photo_generator_path = f'{args.output}/painting2photo'
+
+    tf.saved_model.save(obj=model.painting_generator, export_dir=painting_generator_path)
+    tf.saved_model.save(obj=model.photo_generator, export_dir=photo_generator_path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Test run

I converted my HDF5 weights to SavedModel format via:

```
python -m monet_cyclegan.scripts.h5_to_saved_model --photo2painting build/Monet_CycleGAN_Tutorial/photo2monet.h5 --painting2photo build/Monet_CycleGAN_Tutorial/monet2photo.h5 -o build/Monet_CycleGAN_Tutorial/SavedModel
```

I then converted the SavedModel formatted weights to TensorFlow.js compatible weights:

```
python -m monet_cyclegan.scripts.save_tfjs_weights --painting2photo build/Monet_CycleGAN_Tutorial/SavedModel/painting2photo --photo2painting build/Monet_CycleGAN_Tutorial/SavedModel/photo2painting --output build/Monet_CycleGAN_Tutorial/web
```

Then I copied the weights from `build/Monet_CycleGAN_Tutorial/web` to `cyclegan_website/public/assets/models` and the models worked successfully.

### Changes

- `load_cyclegan_model` will load model depending on weight format.

- Add script to convert HDF5 saved weights/models to SavedModel format.