### PR TITLE
Add logs to visualize model losses in TensorBoard

### DIFF
--- a/Code/monet_cyclegan/modeling/discriminator.py
+++ b/Code/monet_cyclegan/modeling/discriminator.py
@@ -14,7 +14,8 @@ def discriminator() -> tf.keras.Model:
     Next, the outputs are created from this with another 2D Convolutional Neural Network with stride 1.
     Finally, the Discriminator model is created and returned with the input and outputs as parameters.
 
-    :return: Discriminator model with the inputs and outputs as parameters
+    Returns:
+        A discriminator for the CycleGAN.
     """
 
     initializer = tf.random_normal_initializer(0., 0.02)

--- a/Code/monet_cyclegan/modeling/generator.py
+++ b/Code/monet_cyclegan/modeling/generator.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 import tensorflow as tf
 
@@ -10,13 +10,13 @@ def generator(output_channels: int = 3) -> tf.keras.Model:
     The Generator applies an encoder-decoder architecture that down-samples the image and then decodes the image
     through various transpose convolutions. It is inspired by a "U-Net" architecture for image generation,
     which down-samples an image and then applies up-sampling.
-    However, it keeps the information from the old images through the residual blocks (the Concatenate function).
+    However, it keeps the information from the old images through the residual blocks (the Concatenate layer).
 
     Args:
-        output_channels: Default of 3 output channels.
+        output_channels: Number of output channels (default: 3).
 
     Returns:
-        Generator model with the inputs (inputs) and outputs (x) as parameters.
+        A generator for the CycleGAN.
     """
 
     down_stack = [

--- a/Code/monet_cyclegan/modeling/losses.py
+++ b/Code/monet_cyclegan/modeling/losses.py
@@ -3,8 +3,8 @@ import tensorflow as tf
 from ..consts import strategy
 
 with strategy.scope():
-    def discriminator_loss(real: tf.keras.Model,
-                           generated: tf.keras.Model,
+    def discriminator_loss(real: tf.Tensor,
+                           generated: tf.Tensor,
                            label_smoothing: float = 0.3) -> tf.Tensor:
         """
         Sub-function for the discriminator loss, which is the loss metric for the discriminator models.
@@ -30,7 +30,7 @@ with strategy.scope():
         return total_discriminator_loss * 0.5
 
 
-    def generator_loss(generated: tf.keras.Model) -> tf.Tensor:
+    def generator_loss(generated: tf.Tensor) -> tf.Tensor:
         """
         Sub-function for the generator loss, which is the loss metric for the generator models.
 

--- a/Code/monet_cyclegan/modeling/train.py
+++ b/Code/monet_cyclegan/modeling/train.py
@@ -16,7 +16,8 @@ def train_model(cyclegan_model: CycleGan,
                 loss_rate: float,
                 train_dataset: tf.data.Dataset,
                 epochs: int,
-                steps_per_epoch: int) -> None:
+                steps_per_epoch: int,
+                tensorboard_callback: tf.keras.callbacks.Callback) -> None:
     """Train a given CycleGAN model.
 
     Args:
@@ -25,12 +26,19 @@ def train_model(cyclegan_model: CycleGan,
         train_dataset: The data to be used for training.
         epochs: The number of epochs to train the model for.
         steps_per_epoch: The number of steps per epoch.
+        tensorboard_callback: Callback for TensorBoard.
     """
 
     cyclegan_compile_with_loss_rate(cyclegan_model=cyclegan_model, loss_rate=loss_rate)
 
     logger.info(f'Fitting model using {epochs} epochs and {steps_per_epoch} steps per epoch.')
-    cyclegan_model.fit(train_dataset, epochs=epochs, steps_per_epoch=steps_per_epoch)
+
+    tf.config.run_functions_eagerly(True)
+    cyclegan_model.fit(train_dataset,
+                       epochs=epochs,
+                       steps_per_epoch=steps_per_epoch,
+                       callbacks=[tensorboard_callback])
+
     logger.info(f'Finished fitting model.')
 
 

--- a/Code/monet_cyclegan/scripts/train.py
+++ b/Code/monet_cyclegan/scripts/train.py
@@ -1,5 +1,6 @@
 import logging
 from argparse import ArgumentParser
+from datetime import datetime
 
 import tensorflow as tf
 
@@ -47,6 +48,9 @@ def main() -> None:
     epoch_dir = f'{args.output}/{args.artist}/epoch{args.epochs}'
     weights_dir = f'{epoch_dir}/weights'
     log_dir = f'{epoch_dir}/logs/train'
+    fit_log_dir = f'{epoch_dir}/logs/fit/{datetime.now().strftime("%Y%m%d-%H%M%S")}'
+
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=fit_log_dir)
 
     configure_logger(log_dir=log_dir)
     log_args(args=args)
@@ -83,7 +87,8 @@ def main() -> None:
                 loss_rate=args.loss_rate,
                 train_dataset=dataset,
                 epochs=args.epochs,
-                steps_per_epoch=steps_per_epoch)
+                steps_per_epoch=steps_per_epoch,
+                tensorboard_callback=tensorboard_callback)
 
     save_weights(cyclegan_model=model,
                  weights_dir=weights_dir)


### PR DESCRIPTION
Add logs to allow us to visualize generator and discriminator loss during training. Once training is complete, logs will appear in a folder e.g., `Code/build/monet/epoch10/logs/fit`. To visualize the results using TensorBoard, run:

```
tensorboard --logdir Code/build/monet/epoch10/logs/fit
```