### PR TITLE
Set input image background size to 100%

### DIFF
--- a/Code/cyclegan_website/components/ImageInput.tsx
+++ b/Code/cyclegan_website/components/ImageInput.tsx
@@ -76,7 +76,7 @@ const ImageInput = ({ type, modelURL, format }: ImageInputProps) => {
     backgroundImage: string
   ) {
     label.style.backgroundImage = backgroundImage;
-    label.style.backgroundSize = "256px 256px";
+    label.style.backgroundSize = "100% 100%";
     label.style.backgroundRepeat = "no-repeat";
     label.textContent = "";
   };


### PR DESCRIPTION
Set input image background size to `100% 100%`. This makes sure the input image is consistent with the output image for any screen size.