### PR TITLE
Add loading indicator for model inferencing

### DIFF
--- a/Code/cyclegan_website/components/CanvasOutput.tsx
+++ b/Code/cyclegan_website/components/CanvasOutput.tsx
@@ -1,0 +1,23 @@
+import { Loading } from "@nextui-org/react";
+
+const CanvasOutput = ({ type, isLoading }) => {
+  const getDisplay = () => {
+    return isLoading ? "none" : "inline-flex";
+  };
+
+  return (
+    <>
+      {isLoading ? <Loading /> : <></>}
+      <canvas
+        id={type}
+        width={256}
+        height={256}
+        style={{
+          display: getDisplay(),
+        }}
+      />
+    </>
+  );
+};
+
+export default CanvasOutput;

--- a/Code/cyclegan_website/components/ImageInput.tsx
+++ b/Code/cyclegan_website/components/ImageInput.tsx
@@ -8,7 +8,13 @@ import {
 } from "@nextui-org/react";
 import { GraphModel } from "@tensorflow/tfjs";
 import { InferenceSession } from "onnxruntime-web";
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react";
 import {
   createInferenceSession,
   drawOnnxPrediction,
@@ -19,9 +25,15 @@ interface ImageInputProps {
   type: string;
   modelURL: string;
   format: string;
+  onRunInference: Function;
 }
 
-const ImageInput = ({ type, modelURL, format }: ImageInputProps) => {
+const ImageInput = ({
+  type,
+  modelURL,
+  format,
+  onRunInference,
+}: ImageInputProps) => {
   const { theme } = useTheme();
   const [tfModel, setTfModel] = useState(null);
   const [inferenceSession, setInferenceSession] = useState(null);
@@ -73,13 +85,19 @@ const ImageInput = ({ type, modelURL, format }: ImageInputProps) => {
     image.onload = async () => {
       if (format == "onnx") {
         if (inferenceSession != null) {
-          drawOnnxPrediction(inferenceSession, canvas, image);
+          onRunInference(true);
+          drawOnnxPrediction(inferenceSession, canvas, image).then(() => {
+            onRunInference(false);
+          });
         } else {
           console.error(`(${type}) Model not yet loaded.`);
         }
       } else if (format == "tfjs") {
         if (tfModel != null) {
-          drawTfjsPrediction(tfModel, canvas, image);
+          onRunInference(true);
+          drawTfjsPrediction(tfModel, canvas, image).then(() => {
+            onRunInference(false);
+          });
         } else {
           console.error(`(${type}) Model not yet loaded.`);
         }

--- a/Code/cyclegan_website/components/ModelCard.tsx
+++ b/Code/cyclegan_website/components/ModelCard.tsx
@@ -1,4 +1,6 @@
 import { Col, Container, Row, Text } from "@nextui-org/react";
+import { useState } from "react";
+import CanvasOutput from "./CanvasOutput";
 import ImageInput from "./ImageInput";
 
 interface ModelCardProps {
@@ -9,6 +11,8 @@ interface ModelCardProps {
 }
 
 const ModelCard = ({ title, type, modelURL, format }: ModelCardProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+
   return (
     <Container sm>
       <Row align="center">
@@ -25,13 +29,20 @@ const ModelCard = ({ title, type, modelURL, format }: ModelCardProps) => {
       </Row>
       <Row align="center">
         <Col css={{ textAlign: "center" }}>
-          <ImageInput modelURL={modelURL} type={type} format={format} />
+          <ImageInput
+            modelURL={modelURL}
+            type={type}
+            format={format}
+            onRunInference={(result: boolean) => {
+              setIsLoading(result);
+            }}
+          />
         </Col>
         <Col span={1}>
           <Text css={{ fontSize: "3.5vw" }}>→</Text>
         </Col>
         <Col css={{ textAlign: "center" }}>
-          <canvas id={type} width={256} height={256}></canvas>
+          <CanvasOutput type={type} isLoading={isLoading} />
         </Col>
       </Row>
     </Container>


### PR DESCRIPTION
### Description

Added a loading indicator when the model is running an inference. This is mainly useful for the ONNX models since they take much longer to inference than TensorFlow.js models.

### Changes

- Refactored the canvas output into a React component.
- Add an `isLoading` state hook.
- Add loading indicator when `isLoading` is true.

### Issues

The inference loading indicator only works half of the time. The other half of the time, the ONNX model runs the inference before the loading indicator can be rendered, blocking the loading indicator's rendering.