### PR TITLE
Fix RGB distribution plot

### DIFF
--- a/Code/cyclegan_website/pages/utilities/plot_rgb_distribution.tsx
+++ b/Code/cyclegan_website/pages/utilities/plot_rgb_distribution.tsx
@@ -34,16 +34,24 @@ const PlotRGBDistributionPage: NextPage = () => {
       height,
       margin,
       "RGB Value",
-      "Density"
+      "Frequency"
     );
 
     const { rD, gD, bD } = getRGB(img);
     const rData = getRGBFrequency(rD);
     const gData = getRGBFrequency(gD);
     const bData = getRGBFrequency(bD);
-    plotDensity(width, height, svg, rData, "red");
-    plotDensity(width, height, svg, gData, "green");
-    plotDensity(width, height, svg, bData, "blue");
+    const rDataArray = rData.map<[number, number]>((d) => [d.idx, d.freq]);
+    const gDataArray = gData.map<[number, number]>((d) => [d.idx, d.freq]);
+    const bDataArray = bData.map<[number, number]>((d) => [d.idx, d.freq]);
+    const rFreq = rData.map<number>((d) => d.freq);
+    const gFreq = gData.map<number>((d) => d.freq);
+    const bFreq = bData.map<number>((d) => d.freq);
+    const totalFreq = rFreq.concat(gFreq).concat(bFreq);
+    const maxFreq = Math.max(...totalFreq);
+    plotDensity(width, height, svg, rDataArray, "red", maxFreq);
+    plotDensity(width, height, svg, gDataArray, "green", maxFreq);
+    plotDensity(width, height, svg, bDataArray, "blue", maxFreq);
   };
 
   const handleChange = function (event: ChangeEvent<FormElement>) {

--- a/Code/cyclegan_website/utils/plotRGB.ts
+++ b/Code/cyclegan_website/utils/plotRGB.ts
@@ -1,34 +1,12 @@
 import * as d3 from "d3";
 
-// Function to compute density
-function kernelDensityEstimator(kernel, X) {
-  return function (V) {
-    return X.map(function (x) {
-      return [
-        x,
-        d3.mean(V, function (v) {
-          return kernel(x - (v as number));
-        }),
-      ];
-    });
-  };
-}
-
-function kernelEpanechnikov(k) {
-  return function (v) {
-    return Math.abs((v /= k)) <= 1 ? (0.75 * (1 - v * v)) / k : 0;
-  };
-}
-
 export const plotDensity = (
   width: number,
   height: number,
-  svg,
-  data: {
-    freq: number;
-    idx: number;
-  }[],
-  color: string
+  svg: d3.Selection<SVGGElement, unknown, HTMLElement, any>,
+  data: number[][],
+  color: string,
+  maxFreq: number
 ) => {
   console.log(`Creating density plot for the ${color} channel.`);
 
@@ -40,49 +18,36 @@ export const plotDensity = (
     .call(d3.axisBottom(x));
 
   // Add the y axis
-  const y = d3.scaleLinear().range([height, 0]).domain([0, 0.01]);
+  const y = d3.scaleLinear().range([height, 0]).domain([0, maxFreq]);
   svg.append("g").call(d3.axisLeft(y));
 
-  // Compute kernel density estimation
-  const kde = kernelDensityEstimator(kernelEpanechnikov(7), x.ticks(40));
-  const density = kde(
-    data.map(function (d) {
-      return d.freq;
-    })
-  );
+  const area = d3
+    .area()
+    .curve(d3.curveBasis)
+    .x((d) => x(d[0]))
+    .y1((d) => y(d[1]))
+    .y0(height);
 
-  console.log(data);
-
-  // Plot the area
   svg
     .append("path")
-    .datum(density)
+    .datum(data)
     .attr("fill", color)
     .attr("opacity", ".5")
-    .attr(
-      "d",
-      d3
-        .area()
-        .curve(d3.curveBasis)
-        .x((d) => x(d[0]))
-        .y1((d) => y(d[1]))
-        .y0(height)
-    );
+    .attr("d", area as any);
+
+  const path = d3
+    .line()
+    .curve(d3.curveBasis)
+    .x((d) => x(d[0]))
+    .y((d) => y(d[1]));
 
   svg
     .append("path")
-    .datum(density)
+    .datum(data)
     .attr("fill", "none")
     .attr("opacity", "1")
     .attr("stroke", color)
     .attr("stroke-width", 1)
     .attr("stroke-linejoin", "round")
-    .attr(
-      "d",
-      d3
-        .line()
-        .curve(d3.curveBasis)
-        .x((d) => x(d[0]))
-        .y((d) => y(d[1]))
-    );
+    .attr("d", path as any);
 };


### PR DESCRIPTION
Fixed the RGB distribution plot for the website. Before, I tried using a kernel density estimator to create a density plot, however these plots would not match the distributions given by the Python RGB distribution plot or other online RGB distribution plotting tools such as:

- https://www.sisik.eu/histo
- https://pinetools.com/image-histogram
