### PR TITLE
Accept all image types

### DIFF
--- a/Code/cyclegan_website/components/ImageInput.tsx
+++ b/Code/cyclegan_website/components/ImageInput.tsx
@@ -139,7 +139,7 @@ const ImageInput = ({
       <Input
         type="file"
         id={`input-file-upload-${type}`}
-        accept=".jpg, .jpeg, .png"
+        accept="image/*"
         onChange={handleChange}
         css={{
           display: "none",

--- a/Code/cyclegan_website/pages/utilities/plot_rgb_distribution.tsx
+++ b/Code/cyclegan_website/pages/utilities/plot_rgb_distribution.tsx
@@ -99,7 +99,7 @@ const PlotRGBDistributionPage: NextPage = () => {
               <Input
                 type="file"
                 id={"input-file-upload"}
-                accept=".jpg, .jpeg, .png"
+                accept="image/*"
                 onChange={handleChange}
                 css={{
                   display: "none",


### PR DESCRIPTION
Accept all image types from the user, not just JPG and PNG. For example, now the user may upload WEBP and SVG images.