### PR TITLE
Add updated competition models to website

### DIFF
--- a/Code/cyclegan_website/pages/generators/monet2photo.tsx
+++ b/Code/cyclegan_website/pages/generators/monet2photo.tsx
@@ -15,9 +15,16 @@ const Monet2PhotoPage: NextPage = () => {
       />
       <Spacer y={2} />
       <ModelCard
-        title="Our Monet2Photo Generator (Competition)"
-        type="our-competition-monet2photo"
-        modelURL="/assets/models/our_model/monet-competition/painting2photo/model.json"
+        title="Our Monet2Photo Generator (Competition, Final)"
+        type="our-competition-final-monet2photo"
+        modelURL="/assets/models/our_model/monet-competition-final/painting2photo/model.json"
+        format="tfjs"
+      />
+      <Spacer y={2} />
+      <ModelCard
+        title="Our Monet2Photo Generator (Competition, V2)"
+        type="our-competition-v2-monet2photo"
+        modelURL="/assets/models/our_model/monet-competition-v2/painting2photo/model.json"
         format="tfjs"
       />
       <Spacer y={2} />

--- a/Code/cyclegan_website/pages/generators/photo2monet.tsx
+++ b/Code/cyclegan_website/pages/generators/photo2monet.tsx
@@ -15,9 +15,16 @@ const Photo2MonetPage: NextPage = () => {
       />
       <Spacer y={2} />
       <ModelCard
-        title="Our Photo2Monet Generator (Competition)"
-        type="our-competition-photo2monet"
-        modelURL="/assets/models/our_model/monet-competition/photo2painting/model.json"
+        title="Our Photo2Monet Generator (Competition, Final)"
+        type="our-competition-final-photo2monet"
+        modelURL="/assets/models/our_model/monet-competition-final/photo2painting/model.json"
+        format="tfjs"
+      />
+      <Spacer y={2} />
+      <ModelCard
+        title="Our Photo2Monet Generator (Competition, V2)"
+        type="our-competition-v2-photo2monet"
+        modelURL="/assets/models/our_model/monet-competition-v2/photo2painting/model.json"
         format="tfjs"
       />
       <Spacer y={2} />


### PR DESCRIPTION
### Description

Added the updated models to the website alongside the previous model.

### Changes

- Added [our current best competition model](https://www.kaggle.com/code/nguyene/monet-cyclegan-tutorial-489942?scriptVersionId=124318796)
- Changed previous model name to V2

### Notes

Since the previous model name was changed to include "v2", if you have the previous model cached then you will want to manually delete it by going into developer console and deleting the IndexedDB entry for it (`our-competition-photo2monet` and `our-competition-monet2photo`).