### PR TITLE
Refactor image generation to allow for painting2photo

### DIFF
--- a/Code/monet_cyclegan/deployment/generate_images.py
+++ b/Code/monet_cyclegan/deployment/generate_images.py
@@ -6,18 +6,19 @@ import os
 import shutil
 import sys
 
-from ..modeling.model import CycleGan
+import tensorflow as tf
+
 from ..modeling.predict import translate_image
 from ..utils import read_image, read_tfrecorddataset, get_filenames, save_image, tensor_to_image
 
 logger = logging.getLogger(__name__)
 
 
-def generate_image(cyclegan_model: CycleGan, input_path: str, output_dir: str) -> None:
+def generate_image(generator: tf.keras.models.Model, input_path: str, output_dir: str) -> None:
     """Use a CycleGAN model to translate an image to a painting and save it.
 
     Args:
-        cyclegan_model: The CycleGAN model to be used for image generation.
+        generator: The generator model.
         input_path: Path of the image to be translated.
         output_dir: Directory where the generated image will be saved.
     """
@@ -29,7 +30,7 @@ def generate_image(cyclegan_model: CycleGan, input_path: str, output_dir: str) -
 
     image = read_image(path=input_path)
 
-    generated_image = translate_image(cyclegan_model=cyclegan_model,
+    generated_image = translate_image(generator=generator,
                                       image=image)
 
     filename = os.path.basename(input_path)
@@ -41,7 +42,7 @@ def generate_image(cyclegan_model: CycleGan, input_path: str, output_dir: str) -
     logger.info(f"Saved painting style version of '{input_path}' to '{output_path}'.")
 
 
-def generate_images(cyclegan_model: CycleGan,
+def generate_images(generator: tf.keras.models.Model,
                     input_dir: str,
                     input_ext: str,
                     output_dir: str,
@@ -52,7 +53,7 @@ def generate_images(cyclegan_model: CycleGan,
     """Use a CycleGAN model to translate images to paintings and save them.
 
     Args:
-        cyclegan_model: The CycleGAN model to be used for image generation.
+        generator: The generator model.
         input_dir: Directory of images to be translated.
         input_ext: File extension of the input image format.
         output_dir: Directory where the generated images will be saved.
@@ -97,7 +98,7 @@ def generate_images(cyclegan_model: CycleGan,
         logger.info('Generating and saving images.')
 
         for i, image in enumerate(photos):
-            generated_image = translate_image(cyclegan_model=cyclegan_model,
+            generated_image = translate_image(generator=generator,
                                               image=image)
 
             save_image(image=generated_image,
@@ -110,7 +111,7 @@ def generate_images(cyclegan_model: CycleGan,
 
     else:
         for i, filename in enumerate(get_filenames(image_dir=input_dir, ext=input_ext)):
-            generate_image(cyclegan_model=cyclegan_model,
+            generate_image(generator=generator,
                            input_path=filename,
                            output_dir=output_dir)
 

--- a/Code/monet_cyclegan/modeling/predict.py
+++ b/Code/monet_cyclegan/modeling/predict.py
@@ -1,21 +1,20 @@
 import tensorflow as tf
 from numpy import ndarray
 
-from .model import CycleGan
 from ..utils import tensor_to_image
 
 
-def translate_image(cyclegan_model: CycleGan, image: tf.Tensor) -> ndarray:
+def translate_image(generator: tf.keras.models.Model, image: tf.Tensor) -> ndarray:
     """Translate an image to a painting.
 
     Args:
-        cyclegan_model: The CycleGAN model to be used for image generation.
+        generator: The generator model.
         image: The image to be transformed.
 
     Returns:
         The image as a painting in NumPy array format.
     """
 
-    prediction = cyclegan_model.painting_generator(image, training=False)[0]
+    prediction = generator(image, training=False)[0]
     prediction = tensor_to_image(prediction)
     return prediction

--- a/Code/monet_cyclegan/scripts/generate_images.py
+++ b/Code/monet_cyclegan/scripts/generate_images.py
@@ -18,6 +18,7 @@ def main() -> None:
     parser.add_argument('--build-dir', type=str, default=BUILD_DIR)
     parser.add_argument('--photo2painting', type=str, default=None)
     parser.add_argument('--painting2photo', type=str, default=None)
+    parser.add_argument('--type', type=str, default='photo2painting')
     parser.add_argument('--shuffle', action='store_true')
     parser.add_argument('--no-shuffle', dest='shuffle', action='store_false')
     parser.set_defaults(shuffle=False)
@@ -56,17 +57,22 @@ def main() -> None:
         photo2painting_generator_weights_path=photo2painting_path,
         painting2photo_generator_weights_path=painting2photo_path)
 
+    if args.type == 'painting2photo':
+        generator = model.photo_generator
+    else:
+        generator = model.painting_generator
+
     if args.output:
         output_dir = args.output
     else:
         output_dir = f'{epoch_dir}/images'
 
     if args.file:
-        generate_image(cyclegan_model=model,
+        generate_image(generator=generator,
                        input_path=args.file,
                        output_dir=output_dir)
     else:
-        generate_images(cyclegan_model=model,
+        generate_images(generator=generator,
                         input_dir=args.input,
                         input_ext=args.ext,
                         output_dir=output_dir,


### PR DESCRIPTION
Before, the `generate_images` script would only use the painting generator. These changes allow us to choose to use the photo generator.